### PR TITLE
Rename sonic_nas_daemon_LIBADD to sonic_nas_daemon_LDADD.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,12 +10,12 @@ bin_PROGRAMS=sonic_nas_daemon
 
 sonic_nas_daemon_SOURCES=src/main.c src/hald_init.c
 
-sonic_nas_daemon_LIBADD= -lsonic_logging -lsonic_object_library \
-                         -lpthread -lm -lsystemd  -lsonic_nas_ndi \
-                         -lsonic_common -lsonic_nas_common -lsai-common \
-                         -lsonic_nas_interface -lsonic_nas_platform \
-                         -lsonic_hal_routing -lsonic_nas_l2 -lsonic_nas_qos \
-                         -lsonic_nas_packet_io -lsonic_nas_linux -lsonic_nas_acl
+sonic_nas_daemon_LDADD= -lsonic_logging -lsonic_object_library \
+                        -lpthread -lm -lsystemd  -lsonic_nas_ndi \
+                        -lsonic_common -lsonic_nas_common -lsai-common \
+                        -lsonic_nas_interface -lsonic_nas_platform \
+                        -lsonic_hal_routing -lsonic_nas_l2 -lsonic_nas_qos \
+                        -lsonic_nas_packet_io -lsonic_nas_linux -lsonic_nas_acl
 
 sonic_nas_daemon_CPPFLAGS= -I$(top_srcdir)/sonic -I$(includedir)/sonic
 systemdconfdir=/lib/systemd/system


### PR DESCRIPTION
Automake uses *_LDADD for executables, *_LIBADD for libraries.
